### PR TITLE
Adds information about 'requireLatestVersion' in section 'Configure Inputs'

### DIFF
--- a/content/en/Formulas/Configure Inputs.md
+++ b/content/en/Formulas/Configure Inputs.md
@@ -1,7 +1,7 @@
 ---
 title: Configure Inputs
 weight: 35
-description: 'In this section, you will find information about a formula config.json file'
+description: "In this section, you will find information about a formula config.json file"
 ---
 
 ---
@@ -12,13 +12,15 @@ The **config.json** file contains the formula's input parameters. It allows the 
 
 These input parameters are made up of the following fields:
 
-* a **`docker image builder`** \(according to the programming language chose at the formula creation\)
-* the formula **`inputs parameters list`**.
+- a **`docker image builder`** \(according to the programming language chose at the formula creation\);
+- the formula **`inputs parameters list`**; and
+- a **`require latest version`** boolean, indicating the need (or not) of the formula to run in the last available version of a repository.
 
 ```text
 {
   "dockerImageBuilder": "dockerImage",
-  "inputs": []
+  "inputs": [],
+  "requireLatestVersion": false,
 }
 ```
 
@@ -28,7 +30,7 @@ Each input parameter is composed of the following fields:
 
 ### Mandatory fields
 
-* `name`: variable name to extract.
+- `name`: variable name to extract.
 
 {{% alert color="warning" %}}
 Once an input value is informed on Ritchie CLI, it is saved as a **local variable** during the formula execution.
@@ -38,16 +40,16 @@ The variable **name** will be convert **uppercase** as the **local variable name
 
 > A good practice is to add a **_`RIT_`** suffix to each **`input name`** to avoid having conflicts with local variables.
 >
-> Example_: `rit_file_name` --&gt; `RIT_FILE_NAME`_
+> Example*: `rit_file_name` --&gt; `RIT_FILE_NAME`*
 
-* `type`:
-  * **text** \(string\),
-  * **bool** \(boolean\),
-  * **password** \(hidden string on CLI\),
-  * **credentials** \(specific type, learn more information_ [_**here**_](/docs-ritchie/credentials/use-credentials-as-formula-inputs/)_\),
-  * **dynamic** _\(associated with the optional `request_info` field below\),_
-  * **path:** enables the autocomplete to inform a path to a folder or a file \(string\).
-* `label`: text appearing on the CLI, asking for the input.
+- `type`:
+  - **text** \(string\),
+  - **bool** \(boolean\),
+  - **password** \(hidden string on CLI\),
+  - **credentials** \(specific type, learn more information\* [**\*here**\_](/docs-ritchie/credentials/use-credentials-as-formula-inputs/)\_\),
+  - **dynamic** _\(associated with the optional `request_info` field below\),_
+  - **path:** enables the autocomplete to inform a path to a folder or a file \(string\).
+- `label`: text appearing on the CLI, asking for the input.
 
 #### Input example with mandatory fields:
 
@@ -81,11 +83,11 @@ The variable **name** will be convert **uppercase** as the **local variable name
 
 ### Some observations regarding the **`multiselect` type**
 
-* To select one of the options with the `multiselect` type, you must press the `space` key \(the `enter` key will move to the next input, if any\)
+- To select one of the options with the `multiselect` type, you must press the `space` key \(the `enter` key will move to the next input, if any\)
 
-* The options selected in the `multiselect` type field will return a string with the options separated by pipe \(`|`\) and without space example: `Monday | Wednesday | Friday`
+- The options selected in the `multiselect` type field will return a string with the options separated by pipe \(`|`\) and without space example: `Monday | Wednesday | Friday`
 
-* It is suggested to use the `required` field as `true`, otherwise, if no option is selected, the local variable will be saved as `undefined`
+- It is suggested to use the `required` field as `true`, otherwise, if no option is selected, the local variable will be saved as `undefined`
 
 #### Parameter example using the autocomplete type:
 
@@ -99,7 +101,7 @@ The variable **name** will be convert **uppercase** as the **local variable name
 
 ### Optional fields
 
-* `default`: default input value \(**if** **null**\).
+- `default`: default input value \(**if** **null**\).
 
 ```text
 {
@@ -118,7 +120,7 @@ In case of fields without a default value, the flag will keep asking for this in
 
 {{% /alert %}}
 
-* `required`: boolean that indicates if the input value is required or optional.
+- `required`: boolean that indicates if the input value is required or optional.
 
 ```text
 {
@@ -129,7 +131,7 @@ In case of fields without a default value, the flag will keep asking for this in
 }
 ```
 
-* `tutorial`: input helper message _\[? for help\]_
+- `tutorial`: input helper message _\[? for help\]_
 
 ```text
 {
@@ -140,7 +142,7 @@ In case of fields without a default value, the flag will keep asking for this in
 }
 ```
 
-* `items`: list of input variable options.
+- `items`: list of input variable options.
 
 ```text
 {
@@ -155,10 +157,10 @@ In case of fields without a default value, the flag will keep asking for this in
 }
 ```
 
-* `cache`:  saves former input values.
-  * `active`: if cache is enabled or not.
-  * `qty`: amount of values to store.
-  * `newLabel`: text appearing on the CLI asking for a new input.
+- `cache`: saves former input values.
+  - `active`: if cache is enabled or not.
+  - `qty`: amount of values to store.
+  - `newLabel`: text appearing on the CLI asking for a new input.
 
 ```text
 {
@@ -174,10 +176,10 @@ In case of fields without a default value, the flag will keep asking for this in
 
 ```
 
-* `condition`: shows this input if the given condition succeeds
-  * `variable`: The variable name used on a previous input for comparison.
-  * `operator`: A logical operator to compare. Supports **`==`**, **`!=`**, **`<`**, **`>`**, **`<=`**, and **`>=`.**
-  * `value`: The desired value to compare to.
+- `condition`: shows this input if the given condition succeeds
+  - `variable`: The variable name used on a previous input for comparison.
+  - `operator`: A logical operator to compare. Supports **`==`**, **`!=`**, **`<`**, **`>`**, **`<=`**, and **`>=`.**
+  - `value`: The desired value to compare to.
 
 ```text
 {
@@ -198,9 +200,9 @@ In case of fields without a default value, the flag will keep asking for this in
 }
 ```
 
-* `pattern`: configure an input value validation.
-  * `regex`: The regex pattern to validate the input.
-  * `mismatchText`: error message when input doesn't match the regex pattern
+- `pattern`: configure an input value validation.
+  - `regex`: The regex pattern to validate the input.
+  - `mismatchText`: error message when input doesn't match the regex pattern
 
 ```text
 {
@@ -220,9 +222,9 @@ The **`dynamic input`** type will be **depreciated** in the **next releases**.
 
 {{% /alert %}}
 
-* `requestInfo`: configuration to get dynamic input type.
-  * `url`: URL to consume a GET service that will return a list of objects.
-  * `jsonPath`: path to the variable to extract from the returned list, for each object. \(Check out [**how works the json path**](https://goessner.net/articles/JsonPath/)\).
+- `requestInfo`: configuration to get dynamic input type.
+  - `url`: URL to consume a GET service that will return a list of objects.
+  - `jsonPath`: path to the variable to extract from the returned list, for each object. \(Check out [**how works the json path**](https://goessner.net/articles/JsonPath/)\).
 
 ```text
 {

--- a/content/en/Formulas/Configure Inputs.md
+++ b/content/en/Formulas/Configure Inputs.md
@@ -12,8 +12,8 @@ The **config.json** file contains the formula's input parameters. It allows the 
 
 These input parameters are made up of the following fields:
 
-- a **`docker image builder`** \(according to the programming language chose at the formula creation\);
-- the formula **`inputs parameters list`**; and
+- a **`docker image builder`** \(according to the programming language chose at the formula creation\)
+- the formula **`inputs parameters list`**.
 - a **`require latest version`** boolean, indicating the need (or not) of the formula to run in the last available version of a repository.
 
 ```text
@@ -157,10 +157,10 @@ In case of fields without a default value, the flag will keep asking for this in
 }
 ```
 
-- `cache`: saves former input values.
-  - `active`: if cache is enabled or not.
-  - `qty`: amount of values to store.
-  - `newLabel`: text appearing on the CLI asking for a new input.
+- `cache`: Saves former input values.
+  - `active`: If the cache is enabled or not.
+  - `qty`: Amount of values to store.
+  - `newLabel`: Text appearing on the CLI asking for new input.
 
 ```text
 {
@@ -176,7 +176,7 @@ In case of fields without a default value, the flag will keep asking for this in
 
 ```
 
-- `condition`: shows this input if the given condition succeeds
+- `condition`: It shows an input if the given condition succeeds.
   - `variable`: The variable name used on a previous input for comparison.
   - `operator`: A logical operator to compare. Supports **`==`**, **`!=`**, **`<`**, **`>`**, **`<=`**, and **`>=`.**
   - `value`: The desired value to compare to.
@@ -200,9 +200,9 @@ In case of fields without a default value, the flag will keep asking for this in
 }
 ```
 
-- `pattern`: configure an input value validation.
+- `pattern`: Configure the input value validation.
   - `regex`: The regex pattern to validate the input.
-  - `mismatchText`: error message when input doesn't match the regex pattern
+  - `mismatchText`: An error message when the input doesn't match the regex pattern.
 
 ```text
 {
@@ -222,9 +222,9 @@ The **`dynamic input`** type will be **depreciated** in the **next releases**.
 
 {{% /alert %}}
 
-- `requestInfo`: configuration to get dynamic input type.
-  - `url`: URL to consume a GET service that will return a list of objects.
-  - `jsonPath`: path to the variable to extract from the returned list, for each object. \(Check out [**how works the json path**](https://goessner.net/articles/JsonPath/)\).
+- `requestInfo`: A configuration to get the dynamic input type.
+  - `url`: An URL to consume a GET service that will return a list of objects.
+  - `jsonPath`: A JSON path where the variable extracts a returned list for every object, see `"jsonPath": $['user']['name']` \(Check out [**how the JSON path works**](https://goessner.net/articles/JsonPath/)\).
 
 ```text
 {

--- a/content/pt-br/Fórmulas/Arquivo Config.md
+++ b/content/pt-br/Fórmulas/Arquivo Config.md
@@ -14,7 +14,7 @@ Essas entradas são feitas para os seguintes campos:
 
 - Uma **imagem para buildar o docker** \(de acordo com a linguagem de programação escolhida para criar a fórmula\);
 - A lista com os parâmetros de entrada de uma fórmula; e
-- O **require latest version** é um parâmetro booleano que indicando a necessidade (ou não) da fórmula ser executada na última versão do repositório.
+- O **require latest version** é um parâmetro booleano que indica a necessidade (ou não) da fórmula ser executada na última versão do repositório.
 
 ```text
 {

--- a/content/pt-br/Fórmulas/Arquivo Config.md
+++ b/content/pt-br/Fórmulas/Arquivo Config.md
@@ -12,13 +12,15 @@ O arquivo config.json contém os parâmetros de entrada da fórmula. Ele permite
 
 Essas entradas são feitas para os seguintes campos:
 
-* Uma **imagem para buildar o docker** \(de acordo com a linguagem de programação escolhida para criar a fórmula\)
-* A lista com os parâmetros de entrada de uma fórmula.
+- Uma **imagem para buildar o docker** \(de acordo com a linguagem de programação escolhida para criar a fórmula\);
+- A lista com os parâmetros de entrada de uma fórmula; e
+- O **`require latest version`** é um parâmetro booleano que indicando a necessidade (ou não) da fórmula ser executada na última versão do repositório.
 
 ```text
 {
   "dockerImageBuilder": "dockerImage",
-  "inputs": []
+  "inputs": [],
+  "requireLatestVersion": false,
 }
 ```
 
@@ -28,7 +30,7 @@ Cada parâmetro de entrada é composto pelos seguintes campos:
 
 ### Campos obrigatórios
 
-* `name`: nome da variável para extração.
+- `name`: nome da variável para extração.
 
 {{% alert color="warning" %}}
 
@@ -40,16 +42,16 @@ O nome da variável será convertida em maiúscula como o nome da variável loca
 
 > Uma boa prática é adicionar o sufixo **_`RIT_`** para cada **`input name`** para evitar conflitos com variáveis locais.
 >
-> Exemplo_: `rit_file_name` --&gt; `RIT_FILE_NAME`_
+> Exemplo*: `rit_file_name` --&gt; `RIT_FILE_NAME`*
 
-* `type`:
-  * **text** \(string\),
-  * **bool** \(boolean\),
-  * **password** \(string escondida no CLI\),
-  * **credentials** __\(tipo específico, veja mais sobre [**aqui**](https://docs.ritchiecli.io/tutorials/credentials#how-to-use-credentials-as-formula-inputs)\)
-  * **dynamic** \(associado  ao campo opcional`request_info`\)
-  * **path:** habilita o `autocomplete` para o usuário informar o passo para uma pasta ou um arquivo \(string\).
-* `label`: texto que aparecerá no CLI para pedir o input ao usuário.
+- `type`:
+  - **text** \(string\),
+  - **bool** \(boolean\),
+  - **password** \(string escondida no CLI\),
+  - **credentials** \_\_\(tipo específico, veja mais sobre [**aqui**](https://docs.ritchiecli.io/tutorials/credentials#how-to-use-credentials-as-formula-inputs)\)
+  - **dynamic** \(associado ao campo opcional`request_info`\)
+  - **path:** habilita o `autocomplete` para o usuário informar o passo para uma pasta ou um arquivo \(string\).
+- `label`: texto que aparecerá no CLI para pedir o input ao usuário.
 
 #### Exemplo de parâmetro de entrada com campos obrigatórios:
 
@@ -83,11 +85,11 @@ O nome da variável será convertida em maiúscula como o nome da variável loca
 
 ### Algumas observações a respeito o tipo **`multiselect`**
 
-* Para selecionar uma das opções com tipo `multiselect`, você deve apertar a chave `space` \(a chave`enter` irá mover para o próximo parâmetro de entrada, se houver\).
+- Para selecionar uma das opções com tipo `multiselect`, você deve apertar a chave `space` \(a chave`enter` irá mover para o próximo parâmetro de entrada, se houver\).
 
-* As opções selecionadas no campo do tipo `multiselect` irão retornar uma string com as opções separadas por barra \(`|`\) e sem espaço, por exemplo: `Monday | Wednesday | Friday`.
+- As opções selecionadas no campo do tipo `multiselect` irão retornar uma string com as opções separadas por barra \(`|`\) e sem espaço, por exemplo: `Monday | Wednesday | Friday`.
 
-* É sugerido que você use o campo `obrigatório` como`true`, caso contrário, se não houver uma opção selecionada, a variável local será salva como `undefined` .
+- É sugerido que você use o campo `obrigatório` como`true`, caso contrário, se não houver uma opção selecionada, a variável local será salva como `undefined` .
 
 #### Exemplo de parâmetro de entrada usando o tipo autocomplete:
 
@@ -101,7 +103,7 @@ O nome da variável será convertida em maiúscula como o nome da variável loca
 
 ### Campos opcionais
 
-* `default`: valor padrão do parâmetro \(se nulo\).
+- `default`: valor padrão do parâmetro \(se nulo\).
 
 ```text
 {
@@ -120,7 +122,7 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 
 {{% /alert %}}
 
-* `required`: boolean que indica se um campo é obrigatório ou opcional.
+- `required`: boolean que indica se um campo é obrigatório ou opcional.
 
 ```text
 {
@@ -131,7 +133,7 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 }
 ```
 
-* `tutorial`: campo de ajuda para o parâmetro de entrada _\[? for help\]_
+- `tutorial`: campo de ajuda para o parâmetro de entrada _\[? for help\]_
 
 ```text
 {
@@ -142,7 +144,7 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 }
 ```
 
-* `items`: lista de opções para o parâmetro.
+- `items`: lista de opções para o parâmetro.
 
 ```text
 {
@@ -157,10 +159,10 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 }
 ```
 
-* `cache`:  salva valores de parâmetros de entrada anteriores.
-  * `active`: se o cache é habilitado ou não.
-  * `qty`: quantidade de valor armazenadas no cache.
-  * `newLabel`: texto que aparecerá no CLI para pedir um novo input ao usuário.
+- `cache`: salva valores de parâmetros de entrada anteriores.
+  - `active`: se o cache é habilitado ou não.
+  - `qty`: quantidade de valor armazenadas no cache.
+  - `newLabel`: texto que aparecerá no CLI para pedir um novo input ao usuário.
 
 ```text
 {
@@ -176,11 +178,11 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 
 ```
 
-* `condition`: esse parâmetro só aparece se condicional funcionar.
+- `condition`: esse parâmetro só aparece se condicional funcionar.
 
-  * `variable`: o nome da variável usada em um parâmetro anterior para comparação.
-  * `operator`: o operador lógico usado para comparar. Suporta `==`, `!=`, `<`, `>`, `<=`, and `>=`
-  * `value`: o valor que se deseja usar para comparação.
+  - `variable`: o nome da variável usada em um parâmetro anterior para comparação.
+  - `operator`: o operador lógico usado para comparar. Suporta `==`, `!=`, `<`, `>`, `<=`, and `>=`
+  - `value`: o valor que se deseja usar para comparação.
 
 ```text
 {
@@ -201,10 +203,10 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 }
 ```
 
-* `pattern`: configura a validação de um parâmetro de entrada.
+- `pattern`: configura a validação de um parâmetro de entrada.
 
-  * `regex`: o  modelo regex para validar o parâmetro.
-  * `mismatchText`: a mensagem de erro caso o parâmetro de entrada seja invalidado pelo regex.
+  - `regex`: o modelo regex para validar o parâmetro.
+  - `mismatchText`: a mensagem de erro caso o parâmetro de entrada seja invalidado pelo regex.
 
 ```text
 {
@@ -224,10 +226,10 @@ O tipo de **`entrada dinâmico`** será **depreciado** nas **próximas liberaç�
 
 {{% /alert %}}
 
-* `requestInfo`: configuração para ter o parâmetro de entrada de tipo dinâmico.
+- `requestInfo`: configuração para ter o parâmetro de entrada de tipo dinâmico.
 
-  * `url`: URL que consome o serviço GET, responsável por retornar a lista de objetos.
-  * `jsonPath`: caminho da variável para extrair da lista retornada uma variável de cada objeto. \(Veja mais sobre [**como funciona esse path json**](https://goessner.net/articles/JsonPath/)\).
+  - `url`: URL que consome o serviço GET, responsável por retornar a lista de objetos.
+  - `jsonPath`: caminho da variável para extrair da lista retornada uma variável de cada objeto. \(Veja mais sobre [**como funciona esse path json**](https://goessner.net/articles/JsonPath/)\).
 
 ```text
 {

--- a/content/pt-br/Fórmulas/Arquivo Config.md
+++ b/content/pt-br/Fórmulas/Arquivo Config.md
@@ -14,7 +14,7 @@ Essas entradas são feitas para os seguintes campos:
 
 - Uma **imagem para buildar o docker** \(de acordo com a linguagem de programação escolhida para criar a fórmula\);
 - A lista com os parâmetros de entrada de uma fórmula; e
-- O **`require latest version`** é um parâmetro booleano que indicando a necessidade (ou não) da fórmula ser executada na última versão do repositório.
+- O **require latest version** é um parâmetro booleano que indicando a necessidade (ou não) da fórmula ser executada na última versão do repositório.
 
 ```text
 {

--- a/content/pt-br/Fórmulas/Arquivo Config.md
+++ b/content/pt-br/Fórmulas/Arquivo Config.md
@@ -12,9 +12,9 @@ O arquivo config.json contém os parâmetros de entrada da fórmula. Ele permite
 
 Essas entradas são feitas para os seguintes campos:
 
-- Uma **imagem para buildar o docker** \(de acordo com a linguagem de programação escolhida para criar a fórmula\);
-- A lista com os parâmetros de entrada de uma fórmula; e
-- O **require latest version** é um parâmetro booleano que indica a necessidade (ou não) da fórmula ser executada na última versão do repositório.
+- Uma **imagem para buildar o docker** \(de acordo com a linguagem de programação escolhida para criar a fórmula\)
+- A lista com os parâmetros de entrada de uma fórmula.
+  - O **require latest version** é um parâmetro booleano que indica a necessidade (ou não) da fórmula ser executada na última versão do repositório.
 
 ```text
 {
@@ -89,7 +89,7 @@ O nome da variável será convertida em maiúscula como o nome da variável loca
 
 - As opções selecionadas no campo do tipo `multiselect` irão retornar uma string com as opções separadas por barra \(`|`\) e sem espaço, por exemplo: `Monday | Wednesday | Friday`.
 
-- É sugerido que você use o campo `obrigatório` como`true`, caso contrário, se não houver uma opção selecionada, a variável local será salva como `undefined` .
+- É sugerido que você use o campo `obrigatório` como `true`, caso contrário, se não houver uma opção selecionada, a variável local será salva como `undefined` .
 
 #### Exemplo de parâmetro de entrada usando o tipo autocomplete:
 
@@ -103,7 +103,7 @@ O nome da variável será convertida em maiúscula como o nome da variável loca
 
 ### Campos opcionais
 
-- `default`: valor padrão do parâmetro \(se nulo\).
+- `default`: Valor padrão do parâmetro \(se nulo\).
 
 ```text
 {
@@ -122,7 +122,7 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 
 {{% /alert %}}
 
-- `required`: boolean que indica se um campo é obrigatório ou opcional.
+- `required`: Boolean que indica se um campo é obrigatório ou opcional.
 
 ```text
 {
@@ -133,7 +133,7 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 }
 ```
 
-- `tutorial`: campo de ajuda para o parâmetro de entrada _\[? for help\]_
+- `tutorial`: Campo de ajuda para o parâmetro de entrada _\[? for help\]_
 
 ```text
 {
@@ -144,7 +144,7 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 }
 ```
 
-- `items`: lista de opções para o parâmetro.
+- `items`: Lista de opções para o parâmetro.
 
 ```text
 {
@@ -159,10 +159,10 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 }
 ```
 
-- `cache`: salva valores de parâmetros de entrada anteriores.
-  - `active`: se o cache é habilitado ou não.
-  - `qty`: quantidade de valor armazenadas no cache.
-  - `newLabel`: texto que aparecerá no CLI para pedir um novo input ao usuário.
+- `cache`: Salva os valores de parâmetros de entrada anteriores.
+  - `active`: Se o cache é habilitado ou não.
+  - `qty`: A quantidade de valor armazenada no cache.
+  - `newLabel`: Texto que aparece no CLI para pedir um novo input ao usuário.
 
 ```text
 {
@@ -178,11 +178,11 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 
 ```
 
-- `condition`: esse parâmetro só aparece se condicional funcionar.
+- `condition`: Esse parâmetro só aparece se a condicional funcionar.
 
-  - `variable`: o nome da variável usada em um parâmetro anterior para comparação.
-  - `operator`: o operador lógico usado para comparar. Suporta `==`, `!=`, `<`, `>`, `<=`, and `>=`
-  - `value`: o valor que se deseja usar para comparação.
+  - `variable`: O nome da variável usada em um parâmetro anterior para comparação.
+  - `operator`: O operador lógico usado para comparar. Suporta `==`, `!=`, `<`, `>`, `<=`, and `>=`
+  - `value`: O valor que você deseja usar para comparação.
 
 ```text
 {
@@ -203,10 +203,10 @@ Caso não haja campos com valor default, a flag continuará solicitando os parâ
 }
 ```
 
-- `pattern`: configura a validação de um parâmetro de entrada.
+- `pattern`: Configura a validação de um parâmetro de entrada.
 
-  - `regex`: o modelo regex para validar o parâmetro.
-  - `mismatchText`: a mensagem de erro caso o parâmetro de entrada seja invalidado pelo regex.
+  - `regex`: O modelo regex para validar o parâmetro.
+  - `mismatchText`: A mensagem de erro se o parâmetro de entrada seja invalidado pelo regex.
 
 ```text
 {
@@ -226,10 +226,10 @@ O tipo de **`entrada dinâmico`** será **depreciado** nas **próximas liberaç�
 
 {{% /alert %}}
 
-- `requestInfo`: configuração para ter o parâmetro de entrada de tipo dinâmico.
+- `requestInfo`: Configuração para ter o parâmetro de entrada do tipo dinâmico.
 
-  - `url`: URL que consome o serviço GET, responsável por retornar a lista de objetos.
-  - `jsonPath`: caminho da variável para extrair da lista retornada uma variável de cada objeto. \(Veja mais sobre [**como funciona esse path json**](https://goessner.net/articles/JsonPath/)\).
+  - `url`: Uma URL que consome o serviço GET e é responsável por retornar a lista de objetos.
+  - `jsonPath`: O caminho da variável para extrair da lista retornada uma variável de cada objeto. Exemplo: `"jsonPath": $['user']['name']` \(Veja mais sobre [**como funciona esse path json**](https://goessner.net/articles/JsonPath/)\).
 
 ```text
 {


### PR DESCRIPTION
## Resume
closes #67

Hello Ritchiers, this PR adds information about `requireLatestVersion`, one of the last avaliable configurations on the `config.json`.

### Description
This configuration it's a boolean parameter and force a executation of formula only (depends of value) run in the latest version of repository.
 - More details can be check in the issue related.
 - Some extra changes like double spaces or `*` -> `-` were made automatically by my editor

#### Which section changed
 - Formulas > Configure Inputs

#### Prints
> Portuguese version
> ![image](https://user-images.githubusercontent.com/67295691/117863229-ee0be800-b269-11eb-89eb-9c6ac467c6de.png)
>
> English version
> ![image](https://user-images.githubusercontent.com/67295691/117725288-4fc14900-b1bb-11eb-9078-368211a03a56.png)

