### PR TITLE
Add `rit update workspace` command

### DIFF
--- a/content/en/Reference/List of commands and flags.md
+++ b/content/en/Reference/List of commands and flags.md
@@ -90,11 +90,12 @@ The rit build formula command was deprecated from Ritchie's version 2.5.0.
 
 ### Workspace commands
 
-| Commands             | Operation                             |
-| :------------------- | :------------------------------------ |
-| rit list workspace   | list all formula's workspaces         |
-| rit add workspace    | add a new workspace                   |
-| rit delete workspace | delete a specific formula's workspace |
+| Commands             | Operation                                                                                         |
+| :------------------- | :-------------------------------------------------------------------------------------------------|
+| rit list workspace   | list all formula's workspaces                                                                     |
+| rit add workspace    | add a new workspace                                                                               |
+| rit delete workspace | delete a specific formula's workspace                                                             |
+| rit update workspace | update a specific formula's workspace \(to access new formulas from this workspace with Ritchie\) |
 
 ## Flags
 

--- a/content/en/Standard Inputs/Core Commands.md
+++ b/content/en/Standard Inputs/Core Commands.md
@@ -94,3 +94,23 @@ rit delete repo
 ```text
 rit delete repo --name=repo_name
 ```
+
+### Workspace Commands
+
+rit add workspace
+
+```text
+rit add workspace --name=workspace_name --path=path/to/workspace
+```
+
+rit delete workspace
+
+```text
+rit delete workspace --name=workspace_name
+```
+
+rit update workspace
+
+```text
+rit update workspace --name=workspace_name
+```

--- a/content/pt-br/Referência/Lista de comandos e flags.md
+++ b/content/pt-br/Referência/Lista de comandos e flags.md
@@ -96,7 +96,7 @@ O comando rit build formula foi depreciado a partir da versão 2.5.0 do Ritchie.
 | :------------------- | :---------------------------------------------------------------------------------- |
 | rit list workspace   | lista todas as fórmulas do workspace                                                |
 | rit add workspace    | adiciona um novo workspace                                                          |
-| rit delete workspace | apaga um workspace                                                                 |
+| rit delete workspace | apaga um workspace                                                                  |
 | rit update workspace | atualiza um workspace \(para acessar novas fórmulas desse workspace com o Ritchie\) |
 
 ## Flags

--- a/content/pt-br/Referência/Lista de comandos e flags.md
+++ b/content/pt-br/Referência/Lista de comandos e flags.md
@@ -92,11 +92,12 @@ O comando rit build formula foi depreciado a partir da versão 2.5.0 do Ritchie.
 
 ### Comandos de Workspaces
 
-| Comandos             | Operações                                  |
-| :------------------- | :----------------------------------------- |
-| rit list workspace   | lista todas as fórmulas do workspace       |
-| rit add workspace    | adiciona um novo workspace                 |
-| rit delete workspace | remove uma fórmula específica do workspace |
+| Comandos             | Operações                                                                           |
+| :------------------- | :---------------------------------------------------------------------------------- |
+| rit list workspace   | lista todas as fórmulas do workspace                                                |
+| rit add workspace    | adiciona um novo workspace                                                          |
+| rit delete workspace | apaga um workspace                                                                 |
+| rit update workspace | atualiza um workspace \(para acessar novas fórmulas desse workspace com o Ritchie\) |
 
 ## Flags
 

--- a/content/pt-br/Standard Inputs/Comandos Core.md
+++ b/content/pt-br/Standard Inputs/Comandos Core.md
@@ -95,7 +95,7 @@ rit delete repo
 rit delete repo --name=repo_name
 ```
 
-### Comandos de workspace
+### Comandos de Workspace
 
 rit add workspace
 

--- a/content/pt-br/Standard Inputs/Comandos Core.md
+++ b/content/pt-br/Standard Inputs/Comandos Core.md
@@ -94,3 +94,23 @@ rit delete repo
 ```text
 rit delete repo --name=repo_name
 ```
+
+### Comandos de workspace
+
+rit add workspace
+
+```text
+rit add workspace --name=workspace_name --path=path/to/workspace
+```
+
+rit delete workspace
+
+```text
+rit delete workspace --name=workspace_name
+```
+
+rit update workspace
+
+```text
+rit update workspace --name=workspace_name
+```


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

- Addition of the new core command `rit update workspace`.

https://user-images.githubusercontent.com/22433243/118698408-bd3a2e80-b7e6-11eb-93c3-c25806a1ccae.mp4

Related PR: https://github.com/ZupIT/ritchie-cli/pull/922
Related ISSUE: https://github.com/ZupIT/ritchie-cli/issues/865

- Update the portuguese explanation for the `rit delete workspace` command.
- Add Workspace Commands to Input Flags sections (EN + PT)