### PR TITLE
add installers linux and winget (EN + PT)

### DIFF
--- a/content/en/Getting Started/Linux.md
+++ b/content/en/Getting Started/Linux.md
@@ -16,19 +16,41 @@ Once you have it, just run the command below at your terminal.
 
 ## Step 1: Installing command
 
-Copy and paste the command below to run on your terminal: 
+### Latest Version
+
+Copy and paste the command below to run on your terminal:
 
 ```text
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 ```
 
+### Packages
+
+To download a specific package or version, just paste the URL on your browser replacing the `{VERSION}` field according to [the repository's project tags](https://github.com/ZupIT/ritchie-cli/tags):
+
+#### Red Hat Package Manager
+
+```url
+https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchie.rpm
+```
+
+#### Debian
+
+```url
+https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchie.deb
+```
+
+#### Arch Linux
+
+The `tar.gz` package is available on this [Arch Linux user repository](https://aur.archlinux.org/packages/ritchie-cli/) page ([repository reference](https://github.com/avelino/ritchie-cli-archpack)).
+
 {{% alert color="info" %}}
 If you prefer, you also can follow with the[ **manual installation**.](/docs-ritchie/getting-started/manual-installation/)
 {{% /alert %}}
 
-## Step 2: Verify installation 
+## Step 2: Verify installation
 
-You can confirm if your installation went well by running this command: 
+You can confirm if your installation went well by running this command:
 
 ```text
 rit --version

--- a/content/en/Getting Started/Linux.md
+++ b/content/en/Getting Started/Linux.md
@@ -18,7 +18,7 @@ Once you have it, just run the command below at your terminal.
 
 ### Latest Version
 
-Copy and paste the command below to run on your terminal:
+To install the latest version, copy and paste the command below and run it on your terminal:
 
 ```text
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash

--- a/content/en/Getting Started/Windows.md
+++ b/content/en/Getting Started/Windows.md
@@ -33,7 +33,7 @@ If you prefer, you also can proceed with the[ **manual installation**.](/docs-ri
 
 ## Step 2: Verify installation
 
-You can confirm if your installation went well by running this command:
+Confirm if your installation went well, run the command below:
 
 ```text
 rit --version

--- a/content/en/Getting Started/Windows.md
+++ b/content/en/Getting Started/Windows.md
@@ -11,11 +11,18 @@ To install **the latest version of Ritchie** on Windows, you have to download Ri
 ## Step 1: Download the installer
 
 You can download Ritchie:
+
 - Using this link to the [latest version](https://commons-repo.ritchiecli.io/latest/ritchiecli.msi);
 - Or any version you want: just paste the URL on your browser replacing the `{VERSION}` field according to [the repository's project tags](https://github.com/ZupIT/ritchie-cli/tags):
 
 ```url
 https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchiecli.msi
+```
+
+- Or with `Winget`:
+
+```bash
+winget install Ritchie-CLI
 ```
 
 When you finish, follow the instructions on your terminal after running the `rit` command.
@@ -26,7 +33,7 @@ If you prefer, you also can proceed with the[ **manual installation**.](/docs-ri
 
 ## Step 2: Verify installation
 
-You can confirm if your installation went well by running this command: 
+You can confirm if your installation went well by running this command:
 
 ```text
 rit --version

--- a/content/pt-br/Primeiros Passos/Linux.md
+++ b/content/pt-br/Primeiros Passos/Linux.md
@@ -16,19 +16,41 @@ Feito isso, basta executar o comando abaixo no seu terminal.
 
 ## Passo 1: Rode o comando de instalação
 
-Copie e cole o comando abaixo para executar no terminal: 
+### Última versão
+
+Copie e cole o comando abaixo para executar no terminal:
 
 ```text
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 ```
 
+### Pacotes
+
+Para baixar uma versão ou um pacote específico, use as URLs abaixo no seu navegador, substituindo o campo `{VERSION}` de acordo com [a tag do repositório do projeto](https://github.com/ZupIT/ritchie-cli/tags):
+
+#### Red Hat Package Manager
+
+```url
+https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchie.rpm
+```
+
+#### Debian
+
+```url
+https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchie.deb
+```
+
+#### Arch Linux
+
+O pacote `tar.gz` é disponível nesta página: [Arch Linux user repository](https://aur.archlinux.org/packages/ritchie-cli/) ([repositório de referência](https://github.com/avelino/ritchie-cli-archpack)).
+
 {{% alert color="info" %}}
 Se preferir, você também pode seguir com a [**instalação manual**](/docs-ritchie/pt-br/primeiros-passos/instalação-manual/)
 {{% /alert %}}
 
-## Passo 2: Verifique a instalação 
+## Passo 2: Verifique a instalação
 
-Você pode confirmar se a instalação funcionou rodando esse comando: 
+Você pode confirmar se a instalação funcionou rodando esse comando:
 
 ```text
 rit --version

--- a/content/pt-br/Primeiros Passos/Linux.md
+++ b/content/pt-br/Primeiros Passos/Linux.md
@@ -42,7 +42,7 @@ https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchie.deb
 
 #### Arch Linux
 
-O pacote `tar.gz` é disponível nesta página: [**Arch Linux user repository**](https://aur.archlinux.org/packages/ritchie-cli/) ([**repositório de referência**](https://github.com/avelino/ritchie-cli-archpack)).
+O pacote `tar.gz` está disponível na página: [**Arch Linux user repository**](https://aur.archlinux.org/packages/ritchie-cli/) e veja o ([**repositório de referência**](https://github.com/avelino/ritchie-cli-archpack)).
 
 {{% alert color="info" %}}
 Se preferir, você também pode seguir com a [**instalação manual**](/docs-ritchie/pt-br/primeiros-passos/instalação-manual/)

--- a/content/pt-br/Primeiros Passos/Linux.md
+++ b/content/pt-br/Primeiros Passos/Linux.md
@@ -42,7 +42,7 @@ https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchie.deb
 
 #### Arch Linux
 
-O pacote `tar.gz` é disponível nesta página: [Arch Linux user repository](https://aur.archlinux.org/packages/ritchie-cli/) ([repositório de referência](https://github.com/avelino/ritchie-cli-archpack)).
+O pacote `tar.gz` é disponível nesta página: [**Arch Linux user repository**](https://aur.archlinux.org/packages/ritchie-cli/) ([**repositório de referência**](https://github.com/avelino/ritchie-cli-archpack)).
 
 {{% alert color="info" %}}
 Se preferir, você também pode seguir com a [**instalação manual**](/docs-ritchie/pt-br/primeiros-passos/instalação-manual/)

--- a/content/pt-br/Primeiros Passos/Linux.md
+++ b/content/pt-br/Primeiros Passos/Linux.md
@@ -26,7 +26,7 @@ curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 
 ### Pacotes
 
-Para baixar uma versão ou um pacote específico, use as URLs abaixo no seu navegador, substituindo o campo `{VERSION}` de acordo com [a tag do repositório do projeto](https://github.com/ZupIT/ritchie-cli/tags):
+Se você quiser baixar uma versão ou um pacote específico, use as URLs abaixo no seu navegador. Substitua o campo `{VERSION}` de acordo com [**a tag do repositório do seu projeto**](https://github.com/ZupIT/ritchie-cli/tags):
 
 #### Red Hat Package Manager
 

--- a/content/pt-br/Primeiros Passos/Windows.md
+++ b/content/pt-br/Primeiros Passos/Windows.md
@@ -11,11 +11,18 @@ Para instalar a **última versão do Ritchie**, você precisa  fazer o **downloa
 ## Passo 1: Faça download do instalador
 
 Você pode baixar Ritchie:
+
 - Usando esse link da [última versão]((https://commons-repo.ritchiecli.io/latest/ritchiecli.msi))
 - Ou qualquer versão usando a URL no seu navegador, substituindo o campo `{VERSION}` de acordo com [a tag do repositório do projeto](https://github.com/ZupIT/ritchie-cli/tags):
 
 ```url
 https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchiecli.msi
+```
+
+- Ou com `Winget`:
+
+```bash
+winget install Ritchie-CLI
 ```
 
 Agora, siga as instruções que irão aparecer no seu terminal ao executar o comando `rit`.

--- a/content/pt-br/Primeiros Passos/Windows.md
+++ b/content/pt-br/Primeiros Passos/Windows.md
@@ -10,7 +10,7 @@ Para instalar a **última versão do Ritchie**, você precisa  fazer o **downloa
 
 ## Passo 1: Faça download do instalador
 
-Você pode baixar Ritchie:
+Você tem duas formas de instalar o Ritchie: 
 
 - Usando esse link da [**última versão**]((https://commons-repo.ritchiecli.io/latest/ritchiecli.msi)).
 - Ou qualquer versão usando a URL no seu navegador, substituindo o campo `{VERSION}` de acordo com [a tag do repositório do projeto](https://github.com/ZupIT/ritchie-cli/tags):


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

Closes: https://github.com/ZupIT/docs-ritchie/issues/92

## Description

- Adding the information to install Ritchie CLI specific `rpm` and `deb` versions for linux, as well as a reference for Arch Linux.
- Adding the information to install Ritchie CLI  using `winget` for windows.

## Tasks

- [X] English
- [X] Portuguese
