### PR TITLE
Add reviewers workflow

### DIFF
--- a/.github/workflows/add-reviewers.yml
+++ b/.github/workflows/add-reviewers.yml
@@ -1,0 +1,16 @@
+name: Add Reviewers
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add Reviewers
+      uses: madrapps/add-reviewers@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        reviewers: jessica-tw,mdcpmoreira,GuillaumeFalourd
+        re-request-when-approved: true
+        re-request-when-changes-requested: true


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

## Why is it necessary

- To automatically ask to the tech writers or dev to review when a PR is created.