### PR TITLE
Input flags enhancement

### DIFF
--- a/content/en/Formulas/Hello World Formula.md
+++ b/content/en/Formulas/Hello World Formula.md
@@ -16,7 +16,7 @@ Premisse: After you finished the previous steps -installation and initialization
 To do so, you can use the **`rit add repo`** command, or run the command line below:
 
 ```text
-rit add repo --provider=Github --name=demo --repoUrl=https://github.com/ZupIT/ritchie-formulas-demo --priority=1
+rit add repo --provider="Github" --name="demo" --repoUrl="https://github.com/ZupIT/ritchie-formulas-demo" --priority=1
 ```
 
 {{% alert color="info" %}}
@@ -77,7 +77,7 @@ In that case, you won't need to have Golang installed.
 You can also run the command informing the inputs through flags (you can know which flags are available using the **`--help`** flag when executing a command). This way, inputs parameters are informed directly with the command line.
 
 ```text
-rit demo hello-world --rit_input_text=Dennis --rit_input_boolean=true --rit_input_list=everything --rit_input_password=Ritchie
+rit demo hello-world --rit_input_text="Dennis" --rit_input_boolean=true --rit_input_list="everything" --rit_input_password="Ritchie"
 ```
 
 ### **Case 4:** With Input flags and Docker
@@ -85,7 +85,7 @@ rit demo hello-world --rit_input_text=Dennis --rit_input_boolean=true --rit_inpu
 When you combine both  **`input flags`** and the **`--docker`** flag, it is possible to run a command remotely (on a container) with the input parameters directly informed on the command line:
 
 ```text
-rit demo hello-world --rit_input_text=Dennis --rit_input_boolean=true --rit_input_list=everything --rit_input_password=Ritchie --docker
+rit demo hello-world --rit_input_text="Dennis" --rit_input_boolean=true --rit_input_list="everything" --rit_input_password="Ritchie" --docker
 ```
 
 ### **Case 5:** With Stdin

--- a/content/en/Formulas/Rename formulas.md
+++ b/content/en/Formulas/Rename formulas.md
@@ -28,7 +28,7 @@ Example: `rit group old` > `rit group new`
 {{% alert color="info" %}}
 
 - Ritchie will automatically identify the workspace to which the formula belongs.
-  - If you identify more than one workspace with the entered formula, an extra necessary step will be to choose in which workspace the formula should have its name changed.
+  - If you identify more than one workspace with the entered formula, an extra necessary step (_when using prompt execution_) will be to choose in which workspace the formula should have its name changed.
 - This formula includes entry via _flag_, check out more on [**Formula commands**](/standard-inputs/formulas-commands/) page.
   {{% /alert %}}
 

--- a/content/en/Formulas/Rename formulas.md
+++ b/content/en/Formulas/Rename formulas.md
@@ -28,7 +28,7 @@ Example: `rit group old` > `rit group new`
 {{% alert color="info" %}}
 
 - Ritchie will automatically identify the workspace to which the formula belongs.
-  - If you identify more than one workspace with the entered formula, an extra necessary step (_when using prompt execution_) will be to choose in which workspace the formula should have its name changed.
+  - If the CLI identify more than one workspace with the entered formula, an extra step (_when using prompt execution_) will be necessary to identify in which workspace the formula should have its name changed.
 - This formula includes entry via _flag_, check out more on [**Formula commands**](/standard-inputs/formulas-commands/) page.
   {{% /alert %}}
 

--- a/content/en/Standard Inputs/Core Commands.md
+++ b/content/en/Standard Inputs/Core Commands.md
@@ -63,6 +63,12 @@ rit delete env --env="prod"
 
 ### Formula commands
 
+rit set formula-runner
+
+```text
+rit set formula-runner --runner="local"
+```
+
 rit list formula
 
 ```text

--- a/content/en/Standard Inputs/Core Commands.md
+++ b/content/en/Standard Inputs/Core Commands.md
@@ -132,7 +132,7 @@ rit tutorial
 rit tutorial --enabled=true
 ```
 
-### Workspace Commands
+### Workspace commands
 
 rit add workspace
 

--- a/content/en/Standard Inputs/Core Commands.md
+++ b/content/en/Standard Inputs/Core Commands.md
@@ -38,13 +38,13 @@ rit create formula --name="rit group verb noun" --language="go" --workspace="Def
 rit set credential
 
 ```text
-rit set credential --provider=github --fields=username,token --values=Dennis,123456
+rit set credential --provider="github" --fields="username,token" --values="Dennis,123456"
 ```
 
 rit delete credential
 
 ```text
-rit delete credential --provider=github
+rit delete credential --provider="github"
 ```
 
 ### Environment commands
@@ -52,13 +52,13 @@ rit delete credential --provider=github
 rit set env
 
 ```text
-rit set env --env=prod
+rit set env --env="prod"
 ```
 
 rit delete env
 
 ```text
-rit delete env --env=prod
+rit delete env --env="prod"
 ```
 
 ### Formula commands
@@ -66,7 +66,7 @@ rit delete env --env=prod
 rit list formula
 
 ```text
-rit list formula --name=repo_name
+rit list formula --name="repo_name"
 ```
 
 {{% alert color="info" %}}
@@ -76,25 +76,19 @@ If you need to list formulas from every repository you have added, use the flag 
 {{% /alert %}}
 
 ```text
-rit list formula --name=ALL
+rit list formula --name="ALL"
 ```
 
 rit rename formula
 
 ```text
-rit rename formula --oldName='rit group old' --newName='rit group new'
+rit rename formula --oldName="rit group old" --newName="rit group new"
 ```
-
-{{% alert color="info" %}}
-
-When more than one workspace has the old formula, an extra interaction via a prompt for choosing the workspace is executed by Ritchie.
-
-{{% /alert %}}
 
 rit delete formula
 
 ```text
-rit delete formula --workspace=workspace_name --formula="rit group verb noun"
+rit delete formula --workspace="workspace_name" --formula="rit group verb noun"
 ```
 
 ### Repo commands
@@ -102,7 +96,7 @@ rit delete formula --workspace=workspace_name --formula="rit group verb noun"
 rit add repo
 
 ```text
-rit add repo --name=Zup --provider=Github --repoUrl=https://github.com/ZupIT/ritchie-formulas-zup --tag=2.8.9 --token=1324efg
+rit add repo --name="Zup" --provider="Github" --repoUrl="https://github.com/ZupIT/ritchie-formulas-zup" --tag="2.8.9" --token="1324efg"
 ```
 
 {{% alert color="info" %}}
@@ -114,7 +108,7 @@ When the version flag is not passed, ritchie automatically searches for the late
 rit delete repo
 
 ```text
-rit delete repo --name=repo_name
+rit delete repo --name="repo_name"
 ```
 
 rit update repo
@@ -123,22 +117,30 @@ rit update repo
 rit update repo --name="commons" --version="2.0.0"
 ```
 
+### Tutorial command
+
+rit tutorial
+
+```text
+rit tutorial --enabled=true
+```
+
 ### Workspace Commands
 
 rit add workspace
 
 ```text
-rit add workspace --name=workspace_name --path=path/to/workspace
+rit add workspace --name="workspace_name" --path="path/to/workspace"
 ```
 
 rit delete workspace
 
 ```text
-rit delete workspace --name=workspace_name
+rit delete workspace --name="workspace_name"
 ```
 
 rit update workspace
 
 ```text
-rit update workspace --name=workspace_name
+rit update workspace --name="workspace_name"
 ```

--- a/content/en/Standard Inputs/Core Commands.md
+++ b/content/en/Standard Inputs/Core Commands.md
@@ -102,12 +102,13 @@ rit delete formula --workspace="workspace_name" --formula="rit group verb noun"
 rit add repo
 
 ```text
-rit add repo --name="Zup" --provider="Github" --repoUrl="https://github.com/ZupIT/ritchie-formulas-zup" --tag="2.8.9" --token="1324efg"
+rit add repo --name="demo" --provider="Github" --repoUrl="https://github.com/ZupIT/ritchie-formulas-demo" --tag="2.8.9" --token="1324efg"
 ```
 
 {{% alert color="info" %}}
 
-When the version flag is not passed, ritchie automatically searches for the latest version
+When the version flag is not passed, ritchie automatically searches for the latest version.
+The token flag is mandatory when the command is used to add a private repository.
 
 {{% /alert %}}
 

--- a/content/en/Standard Inputs/Core Commands.md
+++ b/content/en/Standard Inputs/Core Commands.md
@@ -107,7 +107,7 @@ rit add repo --name="demo" --provider="Github" --repoUrl="https://github.com/Zup
 
 {{% alert color="info" %}}
 
-When the version flag is not passed, ritchie automatically searches for the latest version.
+When the version flag is not passed, Ritchie automatically searches for the latest version.
 The token flag is mandatory when the command is used to add a private repository.
 
 {{% /alert %}}

--- a/content/en/Standard Inputs/Formulas commands.md
+++ b/content/en/Standard Inputs/Formulas commands.md
@@ -25,6 +25,6 @@ rit demo formula --name="dennis" --surname="ritchie" --dateOfBirth="09/09/1941"
 
 {{% alert color="danger" %}}
 
-The formula's command through Input flags, needs the input parameters that are based on the config.json, in order to work properly.
+In order to work properly, the formula's command through Input flags needs the input parameters based on the config.json. 
 
 {{% /alert %}}

--- a/content/en/Standard Inputs/Formulas commands.md
+++ b/content/en/Standard Inputs/Formulas commands.md
@@ -11,8 +11,6 @@ With formulas, the Input flags are based on the **inputs parameters names** info
 
 1. Formula command: **`rit demo formula`**
 
-   
-
 2. Inputs names asked in the config.json file:
 
    * **`name`**
@@ -22,11 +20,11 @@ With formulas, the Input flags are based on the **inputs parameters names** info
 3. Formula execution with input flags:
 
 ```text
-rit demo formula --name=dennis --surname=ritchie --dateOfBirth=09/09/1941
+rit demo formula --name="dennis" --surname="ritchie" --dateOfBirth="09/09/1941"
 ```
 
 {{% alert color="danger" %}}
 
-The formula's command through Input flags, needs the input parameters that are based on the config.json, in order to work properly. 
+The formula's command through Input flags, needs the input parameters that are based on the config.json, in order to work properly.
 
 {{% /alert %}}

--- a/content/en/Standard Inputs/Input flag.md
+++ b/content/en/Standard Inputs/Input flag.md
@@ -13,8 +13,7 @@ The **Input flags** on Ritchie has been developed to give one more option to use
 In that case, the input parameters need to be informed following this pattern:
 
 ```text
-RIT (GROUP) VERB NOUN
---input_name='input_value'
+RIT (GROUP) VERB NOUN --input_name="input_value"
 ```
 
 {{% /alert %}}

--- a/content/pt-br/Fórmulas/Executar uma fórmula Hello World.md
+++ b/content/pt-br/Fórmulas/Executar uma fórmula Hello World.md
@@ -17,7 +17,7 @@ description: >-
 Para fazer isso, você pode usar o comando **`rit add repo`** , ou executar a linha de comando abaixo:
 
 ```text
-rit add repo --provider=Github --name=demo --repoUrl=https://github.com/ZupIT/ritchie-formulas-demo --priority=1
+rit add repo --provider="Github" --name="demo" --repoUrl="https://github.com/ZupIT/ritchie-formulas-demo" --priority=1
 ```
 
 {{% alert color="info" %}}
@@ -78,7 +78,7 @@ Nesse caso, não é necessário ter Golang instalado.
 Você também pode executar o comando informando as entradas por meio de flags (você pode saber quais flags estão disponíveis usando  a flag **`--help`** ao executar um comando). Desta forma, os parâmetros de entradas são informados diretamente na linha de comando.
 
 ```text
-rit demo hello-world --rit_input_text=Dennis --rit_input_boolean=true --rit_input_list=everything --rit_input_password=Ritchie
+rit demo hello-world --rit_input_text="Dennis" --rit_input_boolean=true --rit_input_list="everything" --rit_input_password="Ritchie"
 ```
 
 ### Caso 4: Usando Input Flags & Docker
@@ -86,7 +86,7 @@ rit demo hello-world --rit_input_text=Dennis --rit_input_boolean=true --rit_inpu
 Ao combinar os **`input flags`** com a flag do **`--docker`**, é possível executar um comando remotamente (em um contêiner) com os parâmetros de entrada informados diretamente na linha de comando:
 
 ```text
-rit demo hello-world --rit_input_text=Dennis --rit_input_boolean=true --rit_input_list=everything --rit_input_password=Ritchie --docker
+rit demo hello-world --rit_input_text="Dennis" --rit_input_boolean=true --rit_input_list="everything" --rit_input_password="Ritchie" --docker
 ```
 
 ### Caso 5: Usando Stdin

--- a/content/pt-br/Fórmulas/Renomear Fórmulas.md
+++ b/content/pt-br/Fórmulas/Renomear Fórmulas.md
@@ -28,7 +28,7 @@ Exemplo: `rit group old` > `rit group new`
 {{% alert color="info" %}}
 
 - O Ritchie identificará automaticamente o workspace a qual a fórmula pertence.
-  - Caso identifique mais de um workspace com a fórmula informada, um passo extra necessário (_quando for usada a execução via prompt_) será executado pelo Ritchie para escolha do workspace a qual deve ter a fórmula renomeada.
+  - Caso o CLI identifique mais de um workspace com a fórmula informada, um passo extra necessário (_quando for usada a execução via prompt_) será pedido pelo Ritchie para escolha do workspace a qual deve ter a fórmula renomeada.
 - Essa fórmula possui entrada via _flags_, mais informações em [**Commandos core > Comandos de fórmula**](/pt-br/standard-inputs/comandos-core/#comandos-de-fórmula).
   {{% /alert %}}
 

--- a/content/pt-br/Fórmulas/Renomear Fórmulas.md
+++ b/content/pt-br/Fórmulas/Renomear Fórmulas.md
@@ -28,7 +28,7 @@ Exemplo: `rit group old` > `rit group new`
 {{% alert color="info" %}}
 
 - O Ritchie identificará automaticamente o workspace a qual a fórmula pertence.
-  - Caso identifique mais de um workspace com a fórmula informada, um passo extra necessário será executado pelo Ritchie para escolha do workspace a qual deve ter a fórmula renomeada.
+  - Caso identifique mais de um workspace com a fórmula informada, um passo extra necessário (_quando for usada a execução via prompt_) será executado pelo Ritchie para escolha do workspace a qual deve ter a fórmula renomeada.
 - Essa fórmula possui entrada via _flags_, mais informações em [**Commandos core > Comandos de fórmula**](/pt-br/standard-inputs/comandos-core/#comandos-de-fórmula).
   {{% /alert %}}
 

--- a/content/pt-br/Standard Inputs/Comandos Core.md
+++ b/content/pt-br/Standard Inputs/Comandos Core.md
@@ -107,7 +107,7 @@ rit add repo --name="demo" --provider="Github" --repoUrl="https://github.com/Zup
 
 {{% alert color="info" %}}
 
-Quando não é passada a flag de versão, o ritchie busca automaticamente a última versão.
+Quando a flag de versão não é passada, o Ritchie busca automaticamente a última versão.
 A flag de token é obrigatória quando o comando é usado para adicionar um repositório privado.
 
 {{% /alert %}}

--- a/content/pt-br/Standard Inputs/Comandos Core.md
+++ b/content/pt-br/Standard Inputs/Comandos Core.md
@@ -63,6 +63,12 @@ rit delete env --env="prod"
 
 ### Comandos de Fórmulas
 
+rit set formula-runner
+
+```text
+rit set formula-runner --runner="local"
+```
+
 rit list formula
 
 ```text

--- a/content/pt-br/Standard Inputs/Comandos Core.md
+++ b/content/pt-br/Standard Inputs/Comandos Core.md
@@ -38,13 +38,13 @@ rit create formula --name="rit group verb noun" --language="go" --workspace="Def
 rit set credential
 
 ```text
-rit set credential --provider=github --fields=username,token --values=Dennis,123456
+rit set credential --provider="github" --fields="username,token" --values="Dennis,123456"
 ```
 
 rit delete credential
 
 ```text
-rit delete credential --provider=github
+rit delete credential --provider="github"
 ```
 
 ### Comandos de Ambiente
@@ -52,13 +52,13 @@ rit delete credential --provider=github
 rit set env
 
 ```text
-rit set env --env=prod
+rit set env --env="prod"
 ```
 
 rit delete env
 
 ```text
-rit delete env --env=prod
+rit delete env --env="prod"
 ```
 
 ### Comandos de Fórmulas
@@ -66,7 +66,7 @@ rit delete env --env=prod
 rit list formula
 
 ```text
-rit list formula --name=repo_name
+rit list formula --name="repo_name"
 ```
 
 {{% alert color="info" %}}
@@ -76,25 +76,19 @@ Se você precisar listar as fórmulas de todos os repositórios adicionados, use
 {{% /alert %}}
 
 ```text
-rit list formula --name=ALL
+rit list formula --name="ALL"
 ```
 
 rit rename formula
 
 ```text
-rit rename formula --oldName='rit group old' --newName='rit group new'
+rit rename formula --oldName="rit group old" --newName="rit group new"
 ```
-
-{{% alert color="info" %}}
-
-Quando mais de um workspace possui o mesmo nome da fórmula antiga, uma interação extra via prompt para escolha do workspace é executada pelo Ritchie
-
-{{% /alert %}}
 
 rit delete formula
 
 ```text
-rit delete formula --workspace=nome_do_workspace --formula="rit groupo verbo substantivo"
+rit delete formula --workspace="workspace_name" --formula="rit group verb noun"
 ```
 
 ### Comandos de Repo
@@ -102,7 +96,7 @@ rit delete formula --workspace=nome_do_workspace --formula="rit groupo verbo sub
 rit add repo
 
 ```text
-rit add repo --name=Zup --provider=Github --repoUrl=https://github.com/ZupIT/ritchie-formulas-zup --tag=2.8.9 --token=1324efg
+rit add repo --name="demo" --provider="Github" --repoUrl="https://github.com/ZupIT/ritchie-formulas-demo" --tag="2.8.9" --token="1324efg"
 ```
 
 {{% alert color="info" %}}
@@ -114,7 +108,7 @@ Quando não é passada a flag de versão, o ritchie busca automaticamente a últ
 rit delete repo
 
 ```text
-rit delete repo --name=repo_name
+rit delete repo --name="repo_name"
 ```
 
 rit update repo
@@ -123,22 +117,30 @@ rit update repo
 rit update repo --name="commons" --version="2.0.0"
 ```
 
+### Commando de tutorial
+
+rit tutorial
+
+```text
+rit tutorial --enabled=true
+```
+
 ### Comandos de workspace
 
 rit add workspace
 
 ```text
-rit add workspace --name=workspace_name --path=path/to/workspace
+rit add workspace --name="workspace_name" --path="path/to/workspace"
 ```
 
 rit delete workspace
 
 ```text
-rit delete workspace --name=workspace_name
+rit delete workspace --name="workspace_name"
 ```
 
 rit update workspace
 
 ```text
-rit update workspace --name=workspace_name
+rit update workspace --name="workspace_name"
 ```

--- a/content/pt-br/Standard Inputs/Comandos Core.md
+++ b/content/pt-br/Standard Inputs/Comandos Core.md
@@ -124,7 +124,7 @@ rit update repo
 rit update repo --name="commons" --version="2.0.0"
 ```
 
-### Commando de tutorial
+### Comando de Tutorial
 
 rit tutorial
 

--- a/content/pt-br/Standard Inputs/Comandos Core.md
+++ b/content/pt-br/Standard Inputs/Comandos Core.md
@@ -107,7 +107,8 @@ rit add repo --name="demo" --provider="Github" --repoUrl="https://github.com/Zup
 
 {{% alert color="info" %}}
 
-Quando não é passada a flag de versão, o ritchie busca automaticamente a última versão
+Quando não é passada a flag de versão, o ritchie busca automaticamente a última versão.
+A flag de token é obrigatória quando o comando é usado para adicionar um repositório privado.
 
 {{% /alert %}}
 

--- a/content/pt-br/Standard Inputs/Comandos de fórmulas.md
+++ b/content/pt-br/Standard Inputs/Comandos de fórmulas.md
@@ -13,8 +13,6 @@ Com fórmulas, as Input flags tem como base os **nomes dos parâmetros de entrad
 
 1. Comando de fórmula: **`rit demo formula`**
 
-   
-
 2. Nomes dos parâmetros de entrada que são perguntados pelo arquivo config.json:
 
    * **`name`**
@@ -24,7 +22,7 @@ Com fórmulas, as Input flags tem como base os **nomes dos parâmetros de entrad
 3. Execução da fórmula com Input flags:
 
 ```text
-rit demo formula --name=dennis --surname=ritchie --dateOfBirth=09/09/1941
+rit demo formula --name="dennis" --surname="ritchie" --dateOfBirth="09/09/1941"
 ```
 
 {{% alert color="danger" %}}

--- a/content/pt-br/Standard Inputs/visao geral.md
+++ b/content/pt-br/Standard Inputs/visao geral.md
@@ -16,13 +16,13 @@ Basicamente, há duas formas de informar os parâmetros de entrada diretamente n
 
 {{% alert color="info" %}}
 
-As Input flags do Ritchie foram desenvolvidas para oferecer mais uma opção para quem usa os parâmetros de entrada por meio de linha de comando. 
+As Input flags do Ritchie foram desenvolvidas para oferecer mais uma opção para quem usa os parâmetros de entrada por meio de linha de comando.
 
 Nesse caso, os parâmetros de entrada precisam ser informados seguindo o padrão:
 
-`RIT (GROUP) VERB NOUN --input_name='input_value'` 
+`RIT (GROUP) VERB NOUN --input_name="input_value"`
 {{% /alert %}}
 
-Você pode usar as regras do input flags em: 
+Você pode usar as regras do input flags em:
 
 👉 [**Comandos de fórmulas**](/pt-br/standard-inputs/comandos-de-fórmulas/)


### PR DESCRIPTION
## What has been done

- Standardize input flags on all commands using it (using `""` around each value as it is supported for each OS).
- Update `rit rename formula` explanation about prompt being displayed when 2 workspaces have the same formula command inside them (the prompt will only display if the command doesn't use input flags).
- Add `rit set formula-runner` and `rit tutorial` to input flags core commands.