### PR TITLE
add installation command for sudo-free environments

### DIFF
--- a/content/en/Getting Started/Linux.md
+++ b/content/en/Getting Started/Linux.md
@@ -24,11 +24,16 @@ To install the latest version, copy and paste the command below and run it on yo
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 ```
 
-_Note: To install Ritchie on servers or Docker containers (without `sudo` user), use the following command:_
+{{% alert color="info" %}}
+Note: To install Ritchie on servers or Docker containers (without `sudo` user), use the following command:
 
 ```text
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | sed -e 's/sudo//g' | bash
 ```
+
+{{% /alert %}}
+
+If you prefer, you also can follow with the[ **manual installation**.](/getting-started/manual-installation/)
 
 ### Packages
 

--- a/content/en/Getting Started/Linux.md
+++ b/content/en/Getting Started/Linux.md
@@ -12,7 +12,7 @@ If you want to efficiently use Ritchie on Linux with version **`2.0.5 and earlie
 
 * The **make** command
 
-Once you have it, just run the command below at your terminal. 
+Once you have it, just run the command below at your terminal.
 
 ## Step 1: Installing command
 
@@ -24,19 +24,25 @@ To install the latest version, copy and paste the command below and run it on yo
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 ```
 
+_Note: To install Ritchie on servers or Docker containers (without `sudo` user), use the following command:_
+
+```text
+curl -fsSL https://commons-repo.ritchiecli.io/install.sh | sed -e 's/sudo//g' | bash
+```
+
 ### Packages
 
 To download a specific package or version, just paste the URL on your browser replacing the `{VERSION}` field according to [the repository's project tags](https://github.com/ZupIT/ritchie-cli/tags):
 
 #### Red Hat Package Manager
 
-```url
+```text
 https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchie.rpm
 ```
 
 #### Debian
 
-```url
+```text
 https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchie.deb
 ```
 

--- a/content/en/Getting Started/Macos.md
+++ b/content/en/Getting Started/Macos.md
@@ -31,6 +31,12 @@ The command used to install Ritchie at your terminal is:
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 ```
 
+_Note: To install Ritchie on servers or Docker containers (without `sudo` user), use the following command:_
+
+```text
+curl -fsSL https://commons-repo.ritchiecli.io/install.sh | sed -e 's/sudo//g' | bash
+```
+
 {{% alert color="info" %}}
 If you prefer, you also can follow with the[ **manual installation**.](/getting-started/manual-installation/)
 {{% /alert %}}
@@ -43,9 +49,9 @@ You can also **download the Ritchie CLI package** through the command line below
 curl --output ~/Desktop/Ritchie-CLI-macos-installer-x64.pkg --location https://commons-repo.ritchiecli.io/latest/Ritchie-CLI-macos-installer-x64.pkg
 ```
 
-## Step 2: Verify installation 
+## Step 2: Verify installation
 
-You can confirm if your installation went well by running this command: 
+You can confirm if your installation went well by running this command:
 
 ```text
 rit --version

--- a/content/en/Getting Started/Macos.md
+++ b/content/en/Getting Started/Macos.md
@@ -31,15 +31,16 @@ The command used to install Ritchie at your terminal is:
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 ```
 
-_Note: To install Ritchie on servers or Docker containers (without `sudo` user), use the following command:_
+{{% alert color="info" %}}
+Note: To install Ritchie on servers or Docker containers (without `sudo` user), use the following command:
 
 ```text
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | sed -e 's/sudo//g' | bash
 ```
 
-{{% alert color="info" %}}
-If you prefer, you also can follow with the[ **manual installation**.](/getting-started/manual-installation/)
 {{% /alert %}}
+
+If you prefer, you also can follow with the[ **manual installation**.](/getting-started/manual-installation/)
 
 ### Second option
 

--- a/content/pt-br/Primeiros Passos/Linux.md
+++ b/content/pt-br/Primeiros Passos/Linux.md
@@ -24,19 +24,25 @@ Copie e cole o comando abaixo para executar no terminal:
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 ```
 
+_Observação: Para instalar o Ritchie em servidores ou contêineres Docker (sem o usuário `sudo`), use o seguinte comando:_
+
+```text
+curl -fsSL https://commons-repo.ritchiecli.io/install.sh | sed -e 's/sudo//g' | bash
+```
+
 ### Pacotes
 
 Se você quiser baixar uma versão ou um pacote específico, use as URLs abaixo no seu navegador. Substitua o campo `{VERSION}` de acordo com [**a tag do repositório do seu projeto**](https://github.com/ZupIT/ritchie-cli/tags):
 
 #### Red Hat Package Manager
 
-```url
+```text
 https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchie.rpm
 ```
 
 #### Debian
 
-```url
+```text
 https://commons-repo.ritchiecli.io/{VERSION}/installer/ritchie.deb
 ```
 

--- a/content/pt-br/Primeiros Passos/Linux.md
+++ b/content/pt-br/Primeiros Passos/Linux.md
@@ -24,11 +24,16 @@ Copie e cole o comando abaixo para executar no terminal:
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 ```
 
-_Observação: Para instalar o Ritchie em servidores ou contêineres Docker (sem o usuário `sudo`), use o seguinte comando:_
+{{% alert color="info" %}}
+Observação: Para instalar o Ritchie em servidores ou contêineres Docker (sem o usuário `sudo`), use o seguinte comando:
 
 ```text
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | sed -e 's/sudo//g' | bash
 ```
+
+{{% /alert %}}
+
+Se preferir, você também pode seguir com a [**instalação manual**.](/pt-br/primeiros-passos/instalação-manual/)
 
 ### Pacotes
 

--- a/content/pt-br/Primeiros Passos/Macos.md
+++ b/content/pt-br/Primeiros Passos/Macos.md
@@ -31,16 +31,16 @@ Copie e cole o comando abaixo para executar no terminal:
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 ```
 
-
-_Observação: Para instalar o Ritchie em servidores ou contêineres Docker (sem o usuário `sudo`), use o seguinte comando:_
+{{% alert color="info" %}}
+Observação: Para instalar o Ritchie em servidores ou contêineres Docker (sem o usuário `sudo`), use o seguinte comando:
 
 ```text
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | sed -e 's/sudo//g' | bash
 ```
 
-{{% alert color="info" %}}
-Se preferir, você também pode seguir com a [**instalação manual**.](/pt-br/primeiros-passos/instalação-manual/)
 {{% /alert %}}
+
+Se preferir, você também pode seguir com a [**instalação manual**.](/pt-br/primeiros-passos/instalação-manual/)
 
 ### Segunda opção
 

--- a/content/pt-br/Primeiros Passos/Macos.md
+++ b/content/pt-br/Primeiros Passos/Macos.md
@@ -31,11 +31,18 @@ Copie e cole o comando abaixo para executar no terminal:
 curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
 ```
 
+
+_Observação: Para instalar o Ritchie em servidores ou contêineres Docker (sem o usuário `sudo`), use o seguinte comando:_
+
+```text
+curl -fsSL https://commons-repo.ritchiecli.io/install.sh | sed -e 's/sudo//g' | bash
+```
+
 {{% alert color="info" %}}
 Se preferir, você também pode seguir com a [**instalação manual**.](/pt-br/primeiros-passos/instalação-manual/)
 {{% /alert %}}
 
-###  Segunda opção
+### Segunda opção
 
 Você pode também **baixar o** **pacote do Ritchie CLI** através da linha de comando abaixo, para **instalar ele manualmente**.
 
@@ -43,9 +50,9 @@ Você pode também **baixar o** **pacote do Ritchie CLI** através da linha de c
 curl --output ~/Desktop/Ritchie-CLI-macos-installer-x64.pkg --location https://commons-repo.ritchiecli.io/latest/Ritchie-CLI-macos-installer-x64.pkg
 ```
 
-## Passo 2: Verifique a instalação 
+## Passo 2: Verifique a instalação
 
-Você pode confirmar se a instalação funcionou rodando esse comando: 
+Você pode confirmar se a instalação funcionou rodando esse comando:
 
 ```text
 rit --version


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

Closes: https://github.com/ZupIT/docs-ritchie/issues/111
Closes: https://github.com/ZupIT/ritchie-cli/issues/921

### Description

- Add command to install Ritchie on sudo-free environments to MacOs and Linux Installation sections.