### PR TITLE
add correct youtube video to overview section

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,23 +2,11 @@
 addReviewers: true
 
 # Set to true to add assignees to pull requests
-addAssignees: true
+addAssignees: author
 
 # A list of assignees, overrides reviewers if set
 # assignees:
-#   - jessica-tw
-#   - mdcpmoreira
-#   - GuillaumeFalourd
-#   - lucasdittrichzup
-
-# A number of assignees to add to the pull request
-# Set to 0 to add all of the assignees.
-# Uses numberOfReviewers if unset.
-numberOfAssignees: 0
-
-# A list of assignees, overrides reviewers if set
-# assignees:
-#   - assigneeA
+#   - username
 
 # A number of assignees to add to the pull request
 # Set to 0 to add all of the assignees.

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -4,6 +4,10 @@ addReviewers: true
 # Set to true to add assignees to pull requests
 addAssignees: author
 
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
 # A list of assignees, overrides reviewers if set
 # assignees:
 #   - username

--- a/content/en/Overview.md
+++ b/content/en/Overview.md
@@ -10,7 +10,7 @@ description: 'In this section, you will find all initial information about Ritch
 
 Ritchie is an **open source framework** that allows you to create, store and share any kind of automations, executing them through command lines, to run operations or start workflows.
 
-{{< youtube PtKFco2pIqs >}}
+{{< youtube vN7pdC-A_nQ >}}
 
 ## **Versioning**
 

--- a/content/pt-br/Visão geral.md
+++ b/content/pt-br/Visão geral.md
@@ -10,7 +10,7 @@ description: 'Nesta seção, você vai encontrar todas as informações iniciais
 
 O Ritchie é um **framework open source** que permite criar, armazenar e compartilhar qualquer tipo de automação, executando-as através de linhas de comando, para executar operações ou iniciar fluxos de trabalho.
 
-{{< youtube PtKFco2pIqs >}}
+{{< youtube vN7pdC-A_nQ >}}
 
 ## **Versionamento**
 


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

## What Happened

The `overview` / `visão geral` sections are using this Youtube Vídeo: https://www.youtube.com/watch?v=PtKFco2pIqs&ab_channel=ZUP

## What is expected

The current video is deprecated and we should use the new official video: https://www.youtube.com/watch?v=vN7pdC-A_nQ&list=PLkX9oUrQ1ev72KUhsB5gi80Y5Jb-DCV_F

* * *

_Note: Also testing new action config for reviewers_